### PR TITLE
重なっているブロックに乗れてしまう挙動を修正

### DIFF
--- a/models/player/mario.py
+++ b/models/player/mario.py
@@ -205,13 +205,13 @@ class Mario(pg.sprite.Sprite):
                 self.image = self.__imgs[0]
                 self.__shrink_frame_counter = 0
 
-    def __update_vertical_position(self):
+    def __update_vertical_position(self, value=0):
         if not self.on_ground:
             self.__apply_gravity()
             # 地面に着地した場合
-            if self.rect.y > 200:
+            if self.rect.y > 200 - value:
                 self.vy = 0
-                self.rect.y = 200
+                self.rect.y = 200 - value
                 self.on_ground = True
                 self.leave_block()
             # ブロックに着地した場合
@@ -328,7 +328,10 @@ class Mario(pg.sprite.Sprite):
         self.__handle_jump(keys)
 
         # Y軸方向に移動
-        self.__update_vertical_position()
+        if self.is_big():
+            self.__update_vertical_position(12)
+        else:
+            self.__update_vertical_position()
 
         # 動作に応じた画像に変換
         self.__change_image()

--- a/utils/collision.py
+++ b/utils/collision.py
@@ -88,7 +88,7 @@ def player_block_collision(group, player, blocks, items):
     '''
     collided_blocks = pg.sprite.spritecollide(player, blocks, False)
     if collided_blocks:
-        top_block = max(collided_blocks, key=lambda block: block.rect.top)
+        top_block = min(collided_blocks, key=lambda block: block.rect.top)
         # 上からの衝突
         if player.is_falling() and player.rect.bottom <= top_block.rect.top + 12:
             if not player.on_block:
@@ -104,7 +104,7 @@ def player_block_collision(group, player, blocks, items):
                 top_block.release_item(group, items, player)
         # 左からの衝突
         elif player.rect.right >= top_block.rect.left and player.rect.left < top_block.rect.centerx:
-            player.rect.right = top_block.rect.left + 2
+            player.rect.right = top_block.rect.left - 2
         # 右からの衝突
         elif player.rect.left <= top_block.rect.right and player.rect.right > top_block.rect.centerx:
             player.rect.left = top_block.rect.right + 2


### PR DESCRIPTION
・より高い位置にいるブロックを選択したいためminに変更
・左からふれたときの位置調整を間違えていた為 -2に変更
・着地した際の巨大化時のサイズの違いを考慮するために分岐を追加